### PR TITLE
Fix warning caused by Ruby 2.7 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 sudo: false
+
 language: ruby
+
 rvm:
-  - 2.3.5
-  - 2.4.2
-  - 2.5.1
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
+
+before_install:
+  - gem install -N bundler

--- a/json_refs.gemspec
+++ b/json_refs.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hana"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/json_refs/loader.rb
+++ b/lib/json_refs/loader.rb
@@ -27,8 +27,7 @@ module JsonRefs
     end
 
     def handle(filename)
-      f = open(filename)
-      @body = f.read
+      @body = read_reference_file(filename)
       ext = File.extname(filename)[1..-1]
       ext ||= 'json' if json?(@body)
       ext && EXTENSIONS.include?(ext) ? EXTENSIONS[ext].new.call(@body) : @body
@@ -39,6 +38,16 @@ module JsonRefs
       true
     rescue JSON::ParserError => e
       false
+    end
+
+    private
+
+    def read_reference_file(filename)
+      if RUBY_VERSION >= '2.7.0'
+        URI.open(filename, 'r', &:read)
+      else
+        open(filename, 'r', &:read)
+      end
     end
   end
 end


### PR DESCRIPTION
Opening URI via `Kernel#open` is depreciated from Ruby 2.7.
(see: https://bugs.ruby-lang.org/issues/15893)

This PR is to fix warning caused by the above issue.
