### PR TITLE
Add JsonRefs.dereference as alias of JsonRefs.call

### DIFF
--- a/lib/json_refs.rb
+++ b/lib/json_refs.rb
@@ -2,8 +2,12 @@ require 'json_refs/version'
 require 'json_refs/dereference_handler'
 
 module JsonRefs
-  def self.call(doc, options = {})
-    Dereferencer.new(doc, options).call
+  class << self
+    def call(doc, options = {})
+      Dereferencer.new(doc, options).call
+    end
+
+    alias_method :dereference, :call
   end
 
   class Dereferencer

--- a/spec/json_refs_spec.rb
+++ b/spec/json_refs_spec.rb
@@ -105,5 +105,8 @@ RSpec.describe JsonRefs do
   it "dereference JSON reference" do
     result = JsonRefs.(input)
     expect(result).to eq(expected)
+
+    result = JsonRefs.dereference(input)
+    expect(result).to eq(expected)
   end
 end


### PR DESCRIPTION
Someone including me may feel strange about `JsonRefs.(json)` method call form.
Therefore, I'd like to add `JsonRefs.dereference` method as alias of `JsonRefs.call` method.
This PR is to add `JsonRefs.dereference` method.
