### PR TITLE
keep a type of $ref as a string

### DIFF
--- a/lib/json_refs.rb
+++ b/lib/json_refs.rb
@@ -57,7 +57,7 @@ module JsonRefs
 
     def dereference_local(referenced_path)
       if @options[:resolve_local_ref] === false
-        return { '$ref': referenced_path }
+        return { '$ref' => referenced_path }
       end
 
       klass = JsonRefs::DereferenceHandler::Local
@@ -66,7 +66,7 @@ module JsonRefs
 
     def dereference_file(referenced_path)
       if @options[:resolve_file_ref] === false
-        return { '$ref': referenced_path }
+        return { '$ref' => referenced_path }
       end
 
       klass = JsonRefs::DereferenceHandler::File


### PR DESCRIPTION
When use derefecence option `resolve_local_ref: false` and `resolve_file_ref: false`,
type of `$ref` changed from string to symbol.

This commit keep type of `$ref`.