### PR TITLE
Follow references through files. Make nested refs work 

### DIFF
--- a/lib/json_refs.rb
+++ b/lib/json_refs.rb
@@ -40,7 +40,14 @@ module JsonRefs
       target = paths.inject(@doc) do |obj, key|
         obj[key]
       end
-      target[key] = referenced_value(referenced_path)
+      value = follow_referenced_value(referenced_path)
+      target[key] = value
+    end
+
+    def follow_referenced_value(referenced_path)
+      value = referenced_value(referenced_path)
+      return referenced_value(value['$ref']) if value.is_a?(Hash) && value.has_key?('$ref')
+      value
     end
 
     def referenced_value(referenced_path)

--- a/spec/fixtures/components.yaml
+++ b/spec/fixtures/components.yaml
@@ -1,3 +1,4 @@
 schemas:
   cat:
-    name: Cat
+    $ref: './schemas/cat.yaml'
+

--- a/spec/fixtures/following.yaml
+++ b/spec/fixtures/following.yaml
@@ -1,0 +1,18 @@
+paths:
+  /cats:
+    body:
+      type: array
+      items:
+        $ref: '#/components/Cat'
+  /hounds:
+    body:
+      type: array
+      items:
+        $ref: '#/components/Hound'
+components:
+  Cat:
+    $ref: './components.yaml#/schemas/cat'
+  Hound:
+    $ref: '#/components/Hound'
+  Dog:
+    name: 'Dog'

--- a/spec/fixtures/schemas/cat.yaml
+++ b/spec/fixtures/schemas/cat.yaml
@@ -1,0 +1,1 @@
+title: Cat

--- a/spec/json_refs_spec.rb
+++ b/spec/json_refs_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe JsonRefs do
         "yaml_attr"=>"yaml_value"
       },
       'file_with_pointer' => {
-        "name" => "Cat"
+        "title" => "Cat"
       }
     }
   }
@@ -114,5 +114,14 @@ RSpec.describe JsonRefs do
 
     result = JsonRefs.dereference(input)
     expect(result).to eq(expected)
+  end
+
+  it "follows pointers through files" do
+    result = Dir.chdir('./spec/fixtures') do
+      input = YAML.safe_load(File.read('following.yaml'))
+      JsonRefs.(input)
+    end
+    schema = result.dig('paths', '/cats', 'body', 'items')
+    expect(schema).to eq({ 'title' => 'Cat'})
   end
 end


### PR DESCRIPTION
With this change it is possible to dereference a pointer that points to another file. So if file A has a pointer to _another pointer_ in file B it works as expected.
