### PR TITLE
Do not include unneeded hidden files and binaries into gem

### DIFF
--- a/json_refs.gemspec
+++ b/json_refs.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/tzmfreedom/json_refs"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = Dir['{lib}/**/*', 'LICENSE.txt', 'README.md', 'CHANGELOG.md']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Right now the gemspec includes the following files into the gem:
```
[".gitignore",
 ".rspec",
 ".travis.yml",
 "Gemfile",
 "LICENSE.txt",
 "README.md",
 "Rakefile",
 "bin/console",
 "bin/setup",
 "json_refs.gemspec",
 "lib/json_refs.rb",
 "lib/json_refs/dereference_handler.rb",
 "lib/json_refs/loader.rb",
 "lib/json_refs/version.rb"]
```
Those are not required in the shipped gem and can be excluded.

With the changes only the following files/folders ending up in the gem:

```
["lib/json_refs", "lib/json_refs/dereference_handler.rb", "lib/json_refs/loader.rb",
 "lib/json_refs/version.rb", "lib/json_refs.rb", "LICENSE.txt", "README.md"]
```