### PR TITLE
Fix loading of yaml content for ruby version newer than 3.1.0

### DIFF
--- a/lib/json_refs/loader.rb
+++ b/lib/json_refs/loader.rb
@@ -12,7 +12,7 @@ module JsonRefs
 
     class Yaml
       def call(file)
-        YAML.load(file)
+        RUBY_VERSION >= '3.1.0' ? YAML.unsafe_load(file) : YAML.load(file)
       end
     end
 


### PR DESCRIPTION
With ruby 3.1.0, psych version 4.0.0 got introduced. Starting psych version 4.0.0 the `load` method defaults to `safe_load`.

See https://github.com/ruby/psych/pull/487
See https://stdgems.org/psych/

This got introduced to prevent users from accidentally load yaml content from untrusted user input. But
now breaks certain patterns, when using the gem.

See https://bugs.ruby-lang.org/issues/17866

To still allow users to load trusted documents,
the `unsafe_load` method got introduced.

See https://github.com/ruby/psych/pull/488

I added a ruby version check for backwards
compatibility.